### PR TITLE
Fix/cambios rollback

### DIFF
--- a/app/api/routes/changes.py
+++ b/app/api/routes/changes.py
@@ -73,6 +73,7 @@ async def update_change(
     estado_nuevo["id_incidentes"] = [
         str(incidente.id) for incidente in cambio.incidentes
     ]
+    estado_nuevo["id_problemas"] = [str(problema.id) for problema in cambio.problemas]
     auditoria_crear = AuditoriaCrear(
         tipo_entidad=TipoEntidad.CAMBIO,
         id_entidad=cambio.id,
@@ -142,4 +143,3 @@ async def rollback_change(
     )
 
     return cambio_rollback
-

--- a/app/crud/changes.py
+++ b/app/crud/changes.py
@@ -54,6 +54,8 @@ class CambiosService:
         estado_nuevo["id_problemas"] = [
             str(problema.id) for problema in db_obj.problemas
         ]
+        estado_nuevo["responsable_id"] = None
+
         auditoria_crear = AuditoriaCrear(
             tipo_entidad=TipoEntidad.CAMBIO,
             id_entidad=db_obj.id,
@@ -196,14 +198,37 @@ class CambiosService:
         cambio_actual.prioridad = estado_anterior["prioridad"]
         cambio_actual.estado = estado_anterior["estado"]
         cambio_actual.fecha_cierre = estado_anterior["fecha_cierre"]
+        cambio_actual.responsable_id = estado_anterior["responsable_id"]
 
         id_config_items = [
             uuid.UUID(id_item) for id_item in estado_anterior["id_config_items"]
         ]
+
         config_items = session.exec(
             select(ItemConfiguracion).where(ItemConfiguracion.id.in_(id_config_items))
         ).all()
+
         cambio_actual.config_items = config_items
+
+        id_incidentes = [
+            uuid.UUID(id_incidente) for id_incidente in estado_anterior["id_incidentes"]
+        ]
+
+        incidentes = session.exec(
+            select(Incidente).where(Incidente.id.in_(id_incidentes))
+        ).all()
+
+        cambio_actual.incidentes = incidentes
+
+        id_problemas = [
+            uuid.UUID(id_problema) for id_problema in estado_anterior["id_problemas"]
+        ]
+
+        problemas = session.exec(
+            select(Problema).where(Problema.id.in_(id_problemas))
+        ).all()
+
+        cambio_actual.problemas = problemas
 
         session.add(cambio_actual)
         session.commit()

--- a/app/models/changes.py
+++ b/app/models/changes.py
@@ -42,7 +42,7 @@ class CambioBase(SQLModel):
     fecha_creacion: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     owner_id: None | uuid.UUID = Field(foreign_key="usuarios.id")
     fecha_cierre: datetime | None = Field(default=None)
-    responsable_id: None | uuid.UUID = Field(default=None, foreign_key="usuarios.id")
+    responsable_id: uuid.UUID | None = Field(default=None, foreign_key="usuarios.id")
 
 
 class CambioCrear(SQLModel):

--- a/tests/api/routes/test_changes.py
+++ b/tests/api/routes/test_changes.py
@@ -921,3 +921,67 @@ def test_rollback_change_responsable_id(
     assert cambio_rollback["id"] == cambio_created["id"]
     assert cambio_rollback["responsable_id"] is None
     assert cambio_rollback["responsable_id"] == cambio_created["responsable_id"]
+
+
+def test_rollback_change_incidentes(
+    client: TestClient, session: Session, empleado_token_headers: dict[str, str]
+) -> None:
+    incidentes = session.exec(select(Incidente).limit(2)).all()
+
+    # Given a change
+    cambio_created = create_random_cambio(client, empleado_token_headers)
+
+    update_1 = {"id_incidentes": [str(incidentes[0].id)]}
+    update_2 = {"id_incidentes": [str(incidentes[1].id)]}
+
+    r = client.patch(
+        f"{BASE_URL}/{cambio_created['id']}",
+        json=update_1,
+        headers=empleado_token_headers,
+    )
+
+    assert 200 <= r.status_code < 300
+
+    r = client.patch(
+        f"{BASE_URL}/{cambio_created['id']}",
+        json=update_2,
+        headers=empleado_token_headers,
+    )
+
+    assert 200 <= r.status_code < 300
+
+    # When the user gets the change history
+    r = client.get(
+        f"{BASE_URL}/{cambio_created['id']}/history", headers=empleado_token_headers
+    )
+
+    assert 200 <= r.status_code < 300
+
+    auditorias = r.json()
+    assert auditorias
+
+    # It should return the CREAR and 2 ACTUALIZAR audits
+    assert len(auditorias) == 3
+
+    # We pick the first update done
+    auditoria_crear = auditorias[1]
+
+    assert auditoria_crear["operacion"] == Operacion.ACTUALIZAR
+
+    # When the user rollbacks the change to when it was first updated
+    r = client.post(
+        f"{BASE_URL}/{cambio_created['id']}/rollback",
+        params={"id_auditoria": auditoria_crear["id"]},
+        headers=empleado_token_headers,
+    )
+
+    assert 200 <= r.status_code < 300
+
+    cambio_rollback = r.json()
+
+    # It should return to the state of its first update
+    assert cambio_rollback
+    assert cambio_rollback["id"] == cambio_created["id"]
+    assert len(cambio_rollback["incidentes"]) == len(update_1["id_incidentes"])
+    for i in range(len(update_1["id_incidentes"])):
+        assert cambio_rollback["incidentes"][i]["id"] == update_1["id_incidentes"][i]


### PR DESCRIPTION
Closes #94 

Al agregar problemas e incidentes a cambios se nos pasó también guardarlos y aplicarlos en el rollback. También faltaba aplicar el cambio de responsable.